### PR TITLE
Fix readme usage section outline.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,24 +10,24 @@ Demo: <https://codesandbox.io/s/py5yzmy9jm>
 
 1. Create a shared state container:
 
-```js
-import { createSharedUseState } from 'react-shared-usestate';
+   ```js
+   import { createSharedUseState } from "react-shared-usestate";
 
-// A naming convention could be something like useXState:
-export const useCounterState = createSharedUseState(0);
-```
+   // A naming convention could be something like useXState:
+   export const useCounterState = createSharedUseState(0);
+   ```
 
 2. Use your shared state hook almost exactly as you would a regular useState hook (minus the initial state):
 
-```js
-import { useCounterState } from './state';
+   ```js
+   import { useCounterState } from "./state";
 
-const Counter = props => {
-  const [count, setCount] = useCounterState();
+   const Counter = props => {
+     const [count, setCount] = useCounterState();
 
-  return <button onClick={() => setCount(count + 1)}>{count}</button>;
-};
-```
+     return <button onClick={() => setCount(count + 1)}>{count}</button>;
+   };
+   ```
 
 ## API
 


### PR DESCRIPTION
Now one ordered list is generated, with nested list items containing the code blocks.